### PR TITLE
feat: add project management CRUD

### DIFF
--- a/app.py
+++ b/app.py
@@ -12,6 +12,7 @@ from services.user_service import UserService
 from controllers.department_controller import department_bp
 from controllers.test_case_controller import test_case_bp
 from controllers.case_group_controller import case_group_bp
+from controllers.project_controller import project_bp
 
 
 
@@ -39,6 +40,8 @@ def create_app(config_name="development"):
     app.register_blueprint(user_bp, url_prefix="/api/users")
     # 部门增删改查
     app.register_blueprint(department_bp)
+    # 项目增删改查
+    app.register_blueprint(project_bp)
     # 用例增删改查
     app.register_blueprint(test_case_bp)
     app.register_blueprint(case_group_bp)

--- a/controllers/project_controller.py
+++ b/controllers/project_controller.py
@@ -1,0 +1,86 @@
+from flask import Blueprint, request
+from utils.response import json_response
+from utils.exceptions import BizError
+from services.project_service import ProjectService
+from controllers.auth_helpers import auth_required
+from constants.roles import Role
+
+project_bp = Blueprint("project", __name__, url_prefix="/api/projects")
+
+
+@project_bp.errorhandler(BizError)
+def _biz_error(e: BizError):
+    return json_response(code=e.code, message=e.message), e.code
+
+
+@project_bp.post("")
+@auth_required(roles=[Role.ADMIN, Role.DEPT_ADMIN])
+def create_project():
+    data = request.get_json(silent=True) or {}
+    project = ProjectService.create(
+        department_id=data.get("department_id"),
+        name=data.get("name"),
+        code=data.get("code"),
+        description=data.get("description"),
+        owner_user_id=data.get("owner_user_id"),
+    )
+    return json_response(message="创建成功", data=project.to_dict())
+
+
+@project_bp.get("")
+@auth_required()
+def list_projects():
+    args = request.args
+    department_id = args.get("department_id", type=int)
+    name = args.get("name")
+    code = args.get("code")
+    status = args.get("status")
+    page = args.get("page", default=1, type=int)
+    page_size = args.get("page_size", default=20, type=int)
+    order_desc = args.get("order", "desc").lower() != "asc"
+    items, total = ProjectService.list(
+        department_id=department_id,
+        name=name,
+        code=code,
+        status=status,
+        page=page,
+        page_size=page_size,
+        order_desc=order_desc,
+    )
+    return json_response(
+        data={
+            "items": [i.to_dict() for i in items],
+            "total": total,
+            "page": page,
+            "page_size": page_size,
+        }
+    )
+
+
+@project_bp.get("/<int:project_id>")
+@auth_required()
+def get_project(project_id: int):
+    project = ProjectService.get(project_id)
+    return json_response(data=project.to_dict())
+
+
+@project_bp.put("/<int:project_id>")
+@auth_required(roles=[Role.ADMIN, Role.DEPT_ADMIN])
+def update_project(project_id: int):
+    data = request.get_json(silent=True) or {}
+    project = ProjectService.update(
+        project_id,
+        name=data.get("name"),
+        code=data.get("code"),
+        description=data.get("description"),
+        status=data.get("status"),
+        owner_user_id=data.get("owner_user_id"),
+    )
+    return json_response(message="更新成功", data=project.to_dict())
+
+
+@project_bp.delete("/<int:project_id>")
+@auth_required(roles=[Role.ADMIN, Role.DEPT_ADMIN])
+def delete_project(project_id: int):
+    ProjectService.delete(project_id)
+    return json_response(message="删除成功")

--- a/models/project.py
+++ b/models/project.py
@@ -10,9 +10,9 @@ project.py
 - 权限控制：优先项目成员，继承部门策略。
 """
 
-
 from extensions.database import db
 from .mixins import TimestampMixin, COMMON_TABLE_ARGS
+
 
 class Project(TimestampMixin, db.Model):
     __tablename__ = "project"
@@ -22,17 +22,41 @@ class Project(TimestampMixin, db.Model):
     )
 
     id = db.Column(db.Integer, primary_key=True)
-    department_id = db.Column(db.Integer, db.ForeignKey("department.id", ondelete="CASCADE"), nullable=False)
+    department_id = db.Column(
+        db.Integer, db.ForeignKey("department.id", ondelete="CASCADE"), nullable=False
+    )
     name = db.Column(db.String(128), nullable=False)
     code = db.Column(db.String(64), unique=True)
     status = db.Column(db.String(32), nullable=False, server_default="active")
     description = db.Column(db.Text)
-    owner_user_id = db.Column(db.Integer, db.ForeignKey("user.id", ondelete="SET NULL"))
+    owner_user_id = db.Column(
+        db.Integer, db.ForeignKey("user.id", ondelete="SET NULL")
+    )
 
     department = db.relationship("Department", back_populates="projects")
-    owner = db.relationship("User", backref=db.backref("owned_projects", passive_deletes=True))
-    test_plans = db.relationship("TestPlan", back_populates="project", cascade="all, delete-orphan")
-    members = db.relationship("ProjectMember", back_populates="project", cascade="all, delete-orphan")
+    owner = db.relationship(
+        "User", backref=db.backref("owned_projects", passive_deletes=True)
+    )
+    test_plans = db.relationship(
+        "TestPlan", back_populates="project", cascade="all, delete-orphan"
+    )
+    members = db.relationship(
+        "ProjectMember", back_populates="project", cascade="all, delete-orphan"
+    )
+
+    def to_dict(self):
+        return {
+            "id": self.id,
+            "department_id": self.department_id,
+            "name": self.name,
+            "code": self.code,
+            "status": self.status,
+            "description": self.description,
+            "owner_user_id": self.owner_user_id,
+            "created_at": self.created_at.isoformat() if self.created_at else None,
+            "updated_at": self.updated_at.isoformat() if self.updated_at else None,
+        }
+
 
 class ProjectMember(TimestampMixin, db.Model):
     __tablename__ = "project_member"
@@ -41,9 +65,15 @@ class ProjectMember(TimestampMixin, db.Model):
         COMMON_TABLE_ARGS,
     )
     id = db.Column(db.Integer, primary_key=True)
-    project_id = db.Column(db.Integer, db.ForeignKey("project.id", ondelete="CASCADE"), nullable=False)
-    user_id = db.Column(db.Integer, db.ForeignKey("user.id", ondelete="CASCADE"), nullable=False)
+    project_id = db.Column(
+        db.Integer, db.ForeignKey("project.id", ondelete="CASCADE"), nullable=False
+    )
+    user_id = db.Column(
+        db.Integer, db.ForeignKey("user.id", ondelete="CASCADE"), nullable=False
+    )
     role = db.Column(db.String(32), nullable=False, server_default="tester")
 
     project = db.relationship("Project", back_populates="members")
-    user = db.relationship("User", backref=db.backref("project_memberships", cascade="all, delete-orphan"))
+    user = db.relationship(
+        "User", backref=db.backref("project_memberships", cascade="all, delete-orphan")
+    )

--- a/repositories/project_repository.py
+++ b/repositories/project_repository.py
@@ -1,0 +1,100 @@
+from typing import Optional, List, Tuple
+from sqlalchemy import select, func, desc, asc
+from sqlalchemy.exc import IntegrityError
+from extensions.database import db
+from models.project import Project
+
+
+class ProjectRepository:
+    @staticmethod
+    def create(department_id: int, name: str, code: Optional[str], description: Optional[str], owner_user_id: Optional[int], status: str = "active") -> Project:
+        project = Project(
+            department_id=department_id,
+            name=name.strip(),
+            code=code.strip() if code else None,
+            description=description,
+            owner_user_id=owner_user_id,
+            status=status,
+        )
+        db.session.add(project)
+        db.session.flush()
+        return project
+
+    @staticmethod
+    def get_by_id(project_id: int) -> Optional[Project]:
+        return db.session.get(Project, project_id)
+
+    @staticmethod
+    def get_by_dept_and_name(department_id: int, name: str) -> Optional[Project]:
+        stmt = select(Project).where(Project.department_id == department_id, Project.name == name)
+        return db.session.execute(stmt).scalar_one_or_none()
+
+    @staticmethod
+    def get_by_code(code: str) -> Optional[Project]:
+        stmt = select(Project).where(Project.code == code)
+        return db.session.execute(stmt).scalar_one_or_none()
+
+    @staticmethod
+    def list(
+        department_id: Optional[int] = None,
+        name: Optional[str] = None,
+        code: Optional[str] = None,
+        status: Optional[str] = None,
+        page: int = 1,
+        page_size: int = 20,
+        order_desc: bool = True,
+    ) -> Tuple[List[Project], int]:
+        stmt = select(Project)
+        count_stmt = select(func.count(Project.id))
+        conditions = []
+        if department_id:
+            conditions.append(Project.department_id == department_id)
+        if name:
+            conditions.append(Project.name.ilike(f"%{name.strip()}%"))
+        if code:
+            conditions.append(Project.code.ilike(f"%{code.strip()}%"))
+        if status:
+            conditions.append(Project.status == status)
+        if conditions:
+            stmt = stmt.where(*conditions)
+            count_stmt = count_stmt.where(*conditions)
+        if order_desc:
+            stmt = stmt.order_by(desc(Project.created_at))
+        else:
+            stmt = stmt.order_by(asc(Project.created_at))
+        total = db.session.execute(count_stmt).scalar()
+        stmt = stmt.offset((page - 1) * page_size).limit(page_size)
+        items = db.session.execute(stmt).scalars().all()
+        return items, total
+
+    @staticmethod
+    def update(project: Project, name: Optional[str] = None, code: Optional[str] = None, description: Optional[str] = None, status: Optional[str] = None, owner_user_id: Optional[int] = None) -> Project:
+        if name is not None:
+            project.name = name.strip()
+        if code is not None:
+            project.code = code.strip() if code else None
+        if description is not None:
+            project.description = description
+        if status is not None:
+            project.status = status
+        if owner_user_id is not None:
+            project.owner_user_id = owner_user_id
+        db.session.flush()
+        return project
+
+    @staticmethod
+    def delete(project: Project):
+        db.session.delete(project)
+        db.session.flush()
+
+    @staticmethod
+    def commit():
+        try:
+            db.session.commit()
+        except IntegrityError as e:
+            db.session.rollback()
+            raise e
+
+    @staticmethod
+    def rollback():
+        db.session.rollback()

--- a/services/project_service.py
+++ b/services/project_service.py
@@ -1,0 +1,94 @@
+from typing import Optional, Tuple, List
+from sqlalchemy.exc import IntegrityError
+from repositories.project_repository import ProjectRepository
+from models.project import Project
+from utils.exceptions import BizError
+
+
+class ProjectService:
+    @staticmethod
+    def create(department_id: int, name: str, code: Optional[str], description: Optional[str], owner_user_id: Optional[int]) -> Project:
+        if not name:
+            raise BizError("项目名称不能为空")
+        if ProjectRepository.get_by_dept_and_name(department_id, name):
+            raise BizError("项目名称已存在")
+        if code and ProjectRepository.get_by_code(code):
+            raise BizError("项目代码已存在")
+        project = ProjectRepository.create(
+            department_id=department_id,
+            name=name,
+            code=code,
+            description=description,
+            owner_user_id=owner_user_id,
+            status="active",
+        )
+        try:
+            ProjectRepository.commit()
+        except IntegrityError:
+            raise BizError("创建项目失败：唯一约束冲突")
+        return project
+
+    @staticmethod
+    def get(project_id: int) -> Project:
+        proj = ProjectRepository.get_by_id(project_id)
+        if not proj:
+            raise BizError("项目不存在", code=404)
+        return proj
+
+    @staticmethod
+    def list(
+        department_id: Optional[int] = None,
+        name: Optional[str] = None,
+        code: Optional[str] = None,
+        status: Optional[str] = None,
+        page: int = 1,
+        page_size: int = 20,
+        order_desc: bool = True,
+    ) -> Tuple[List[Project], int]:
+        return ProjectRepository.list(
+            department_id=department_id,
+            name=name,
+            code=code,
+            status=status,
+            page=page,
+            page_size=page_size,
+            order_desc=order_desc,
+        )
+
+    @staticmethod
+    def update(
+        project_id: int,
+        name: Optional[str] = None,
+        code: Optional[str] = None,
+        description: Optional[str] = None,
+        status: Optional[str] = None,
+        owner_user_id: Optional[int] = None,
+    ) -> Project:
+        proj = ProjectService.get(project_id)
+        if name:
+            existing = ProjectRepository.get_by_dept_and_name(proj.department_id, name)
+            if existing and existing.id != proj.id:
+                raise BizError("项目名称已存在")
+        if code:
+            existing_code = ProjectRepository.get_by_code(code)
+            if existing_code and existing_code.id != proj.id:
+                raise BizError("项目代码已存在")
+        ProjectRepository.update(
+            proj,
+            name=name,
+            code=code,
+            description=description,
+            status=status,
+            owner_user_id=owner_user_id,
+        )
+        try:
+            ProjectRepository.commit()
+        except IntegrityError:
+            raise BizError("更新失败：唯一约束冲突")
+        return proj
+
+    @staticmethod
+    def delete(project_id: int):
+        proj = ProjectService.get(project_id)
+        ProjectRepository.delete(proj)
+        ProjectRepository.commit()

--- a/tests/projects/test_projects.py
+++ b/tests/projects/test_projects.py
@@ -1,0 +1,44 @@
+import uuid
+import pytest
+
+
+@pytest.fixture
+def test_project_data(fixed_department_id):
+    suffix = uuid.uuid4().hex[:8]
+    return {
+        "department_id": fixed_department_id,
+        "name": f"测试项目_{suffix}",
+        "code": f"PRJ_{suffix}",
+        "description": "示例项目",
+    }
+
+
+def test_create_project(api_client, test_project_data):
+    resp = api_client.request("POST", "/api/projects", json_data=test_project_data)
+    assert resp.get("_http_status") in (200, 201)
+    data = resp.get("data")
+    assert data and data["name"] == test_project_data["name"]
+
+
+def test_list_projects(api_client, test_project_data):
+    api_client.request("POST", "/api/projects", json_data=test_project_data)
+    resp = api_client.request(
+        "GET", "/api/projects", params={"department_id": test_project_data["department_id"]}
+    )
+    assert resp.get("_http_status") == 200
+    assert "items" in resp.get("data", {})
+
+
+def test_project_lifecycle(api_client, test_project_data):
+    create_resp = api_client.request("POST", "/api/projects", json_data=test_project_data)
+    project_id = create_resp.get("data", {}).get("id")
+    assert project_id
+    detail_resp = api_client.request("GET", f"/api/projects/{project_id}")
+    assert detail_resp.get("data", {}).get("id") == project_id
+    update_data = {"name": test_project_data["name"] + "_upd"}
+    update_resp = api_client.request(
+        "PUT", f"/api/projects/{project_id}", json_data=update_data
+    )
+    assert update_resp.get("data", {}).get("name") == update_data["name"]
+    delete_resp = api_client.request("DELETE", f"/api/projects/{project_id}")
+    assert delete_resp.get("_http_status") in (200, 204)


### PR DESCRIPTION
## Summary
- add project repository, service, and controller for project CRUD
- register project blueprint in app
- add project serialization and tests

## Testing
- `pytest tests/projects/test_projects.py -q` *(fails: ModuleNotFoundError: No module named 'requests')*

------
https://chatgpt.com/codex/tasks/task_e_68c7cb8a56608331a227ce94d2e7c950