### PR TITLE
feat: replace device model delete with enable disable

### DIFF
--- a/app.py
+++ b/app.py
@@ -6,13 +6,13 @@ from extensions.logger import init_logger
 from controllers.auth_controller import auth_bp
 from utils.response import json_response
 from utils.exceptions import BizError
-from utils.response import json_response
 from controllers.user_controller import user_bp
 from services.user_service import UserService
 from controllers.department_controller import department_bp
 from controllers.test_case_controller import test_case_bp
 from controllers.case_group_controller import case_group_bp
 from controllers.project_controller import project_bp
+from controllers.device_model_controller import device_model_bp
 
 
 
@@ -45,6 +45,8 @@ def create_app(config_name="development"):
     # 用例增删改查
     app.register_blueprint(test_case_bp)
     app.register_blueprint(case_group_bp)
+    # 机型管理
+    app.register_blueprint(device_model_bp)
 
 
 

--- a/controllers/device_model_controller.py
+++ b/controllers/device_model_controller.py
@@ -1,0 +1,142 @@
+from flask import Blueprint, request
+
+from constants.roles import Role
+from controllers.auth_helpers import auth_required
+from services.device_model_service import DeviceModelService
+from utils.exceptions import BizError
+from utils.permissions import get_current_user
+from utils.response import json_response
+
+
+device_model_bp = Blueprint("device_model", __name__, url_prefix="/api/device-models")
+
+
+@device_model_bp.errorhandler(BizError)
+def _biz_error(e: BizError):
+    return json_response(code=e.code, message=e.message, data=e.data), e.code
+
+
+def _parse_bool(value):
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, str):
+        lowered = value.strip().lower()
+        if lowered in {"true", "1", "yes"}:
+            return True
+        if lowered in {"false", "0", "no"}:
+            return False
+    return None
+
+
+@device_model_bp.post("")
+@auth_required(roles=[Role.ADMIN, Role.DEPT_ADMIN])
+def create_device_model():
+    user = get_current_user()
+    data = request.get_json(silent=True) or {}
+
+    attributes_json = data.get("attributes_json")
+    if attributes_json is not None and not isinstance(attributes_json, dict):
+        return json_response(code=400, message="attributes_json 必须为对象")
+
+    device_model = DeviceModelService.create(
+        department_id=data.get("department_id"),
+        name=data.get("name"),
+        user=user,
+        category=data.get("category"),
+        model_code=data.get("model_code"),
+        vendor=data.get("vendor"),
+        firmware_version=data.get("firmware_version"),
+        description=data.get("description"),
+        attributes_json=attributes_json,
+    )
+    return json_response(message="创建成功", data=device_model.to_dict())
+
+
+@device_model_bp.get("")
+@auth_required()
+def list_device_models():
+    user = get_current_user()
+    args = request.args
+
+    department_id = args.get("department_id", type=int)
+    if not department_id:
+        return json_response(code=400, message="department_id 不能为空")
+
+    active_param = args.get("active")
+    active = _parse_bool(active_param) if active_param is not None else True
+
+    page = args.get("page", default=1, type=int)
+    page_size = args.get("page_size", default=20, type=int)
+    order_desc = args.get("order", "desc").lower() != "asc"
+
+    items, total = DeviceModelService.list(
+        department_id=department_id,
+        user=user,
+        name=args.get("name"),
+        model_code=args.get("model_code"),
+        category=args.get("category"),
+        active=active,
+        page=page,
+        page_size=page_size,
+        order_desc=order_desc,
+    )
+
+    return json_response(
+        data={
+            "items": [item.to_dict() for item in items],
+            "total": total,
+            "page": page,
+            "page_size": page_size,
+        }
+    )
+
+
+@device_model_bp.get("/<int:device_model_id>")
+@auth_required()
+def get_device_model(device_model_id: int):
+    user = get_current_user()
+    device_model = DeviceModelService.get(device_model_id, user)
+    return json_response(data=device_model.to_dict())
+
+
+@device_model_bp.put("/<int:device_model_id>")
+@auth_required(roles=[Role.ADMIN, Role.DEPT_ADMIN])
+def update_device_model(device_model_id: int):
+    user = get_current_user()
+    data = request.get_json(silent=True) or {}
+
+    attributes_json = data.get("attributes_json")
+    if attributes_json is not None and not isinstance(attributes_json, dict):
+        return json_response(code=400, message="attributes_json 必须为对象")
+
+    if "active" in data:
+        return json_response(code=400, message="active 字段请通过启用/停用接口修改")
+
+    device_model = DeviceModelService.update(
+        device_model_id,
+        user,
+        name=data.get("name"),
+        category=data.get("category"),
+        model_code=data.get("model_code"),
+        vendor=data.get("vendor"),
+        firmware_version=data.get("firmware_version"),
+        description=data.get("description"),
+        attributes_json=attributes_json,
+    )
+    return json_response(message="更新成功", data=device_model.to_dict())
+
+
+@device_model_bp.post("/<int:device_model_id>/enable")
+@auth_required(roles=[Role.ADMIN, Role.DEPT_ADMIN])
+def enable_device_model(device_model_id: int):
+    user = get_current_user()
+    device_model = DeviceModelService.set_active(device_model_id, user, True)
+    return json_response(message="启用成功", data=device_model.to_dict())
+
+
+@device_model_bp.post("/<int:device_model_id>/disable")
+@auth_required(roles=[Role.ADMIN, Role.DEPT_ADMIN])
+def disable_device_model(device_model_id: int):
+    user = get_current_user()
+    device_model = DeviceModelService.set_active(device_model_id, user, False)
+    return json_response(message="停用成功", data=device_model.to_dict())

--- a/models/device_model.py
+++ b/models/device_model.py
@@ -10,9 +10,9 @@ device_model.py
 - (department_id, active) 索引用于活跃设备过滤列表。
 """
 
-
 from extensions.database import db
 from .mixins import TimestampMixin, COMMON_TABLE_ARGS
+
 
 class DeviceModel(TimestampMixin, db.Model):
     __tablename__ = "device_model"
@@ -23,14 +23,36 @@ class DeviceModel(TimestampMixin, db.Model):
     )
 
     id = db.Column(db.Integer, primary_key=True)
-    department_id = db.Column(db.Integer, db.ForeignKey("department.id", ondelete="CASCADE"), nullable=False)
+    department_id = db.Column(
+        db.Integer, db.ForeignKey("department.id", ondelete="CASCADE"), nullable=False
+    )
     name = db.Column(db.String(100), nullable=False)
+    category = db.Column(db.String(64))
     model_code = db.Column(db.String(64))
     vendor = db.Column(db.String(128))
     firmware_version = db.Column(db.String(64))
+    description = db.Column(db.Text)
     attributes_json = db.Column(db.JSON)
     active = db.Column(db.Boolean, nullable=False, server_default="1")
 
     department = db.relationship("Department", back_populates="device_models")
-    plan_device_models = db.relationship("PlanDeviceModel", back_populates="device_model", cascade="all, delete-orphan")
+    plan_device_models = db.relationship(
+        "PlanDeviceModel", back_populates="device_model", cascade="all, delete-orphan"
+    )
     execution_results = db.relationship("ExecutionResult", back_populates="device_model")
+
+    def to_dict(self):
+        return {
+            "id": self.id,
+            "department_id": self.department_id,
+            "name": self.name,
+            "category": self.category,
+            "model_code": self.model_code,
+            "vendor": self.vendor,
+            "firmware_version": self.firmware_version,
+            "description": self.description,
+            "attributes_json": self.attributes_json,
+            "active": bool(self.active),
+            "created_at": self.created_at.isoformat() if self.created_at else None,
+            "updated_at": self.updated_at.isoformat() if self.updated_at else None,
+        }

--- a/repositories/department_repository.py
+++ b/repositories/department_repository.py
@@ -117,7 +117,9 @@ class DepartmentRepository:
             func.count(DepartmentMember.id).label('members_count'),
             func.count(Project.id).label('projects_count'),
             func.count(TestCase.id).label('test_cases_count'),
-            func.count(DeviceModel.id).label('device_models_count')
+            func.sum(
+                case((DeviceModel.active == True, 1), else_=0)  # noqa: E712
+            ).label('device_models_count')
         ).select_from(Department) \
             .outerjoin(DepartmentMember, Department.id == DepartmentMember.department_id) \
             .outerjoin(Project, Department.id == Project.department_id) \
@@ -134,7 +136,7 @@ class DepartmentRepository:
                 "members": result.members_count or 0,
                 "projects": result.projects_count or 0,
                 "test_cases": result.test_cases_count or 0,
-                "device_models": result.device_models_count or 0,
+                "device_models": (result.device_models_count or 0),
             }
 
         # 确保所有部门都有计数数据

--- a/repositories/device_model_repository.py
+++ b/repositories/device_model_repository.py
@@ -1,0 +1,87 @@
+from typing import List, Optional, Tuple
+
+from sqlalchemy import asc, desc, func, select
+from sqlalchemy.exc import IntegrityError
+
+from extensions.database import db
+from models.device_model import DeviceModel
+
+
+class DeviceModelRepository:
+
+    @staticmethod
+    def create(**kwargs) -> DeviceModel:
+        device_model = DeviceModel(**kwargs)
+        db.session.add(device_model)
+        db.session.flush()
+        return device_model
+
+    @staticmethod
+    def get_by_id(device_model_id: int, include_inactive: bool = False) -> Optional[DeviceModel]:
+        stmt = select(DeviceModel).where(DeviceModel.id == device_model_id)
+        if not include_inactive:
+            stmt = stmt.where(DeviceModel.active == True)  # noqa: E712
+        return db.session.execute(stmt).scalar_one_or_none()
+
+    @staticmethod
+    def get_by_dept_and_name(department_id: int, name: str) -> Optional[DeviceModel]:
+        stmt = select(DeviceModel).where(
+            DeviceModel.department_id == department_id,
+            DeviceModel.name == name,
+            DeviceModel.active == True,  # noqa: E712
+        )
+        return db.session.execute(stmt).scalar_one_or_none()
+
+    @staticmethod
+    def list(
+        department_id: int,
+        name: Optional[str] = None,
+        model_code: Optional[str] = None,
+        category: Optional[str] = None,
+        active: Optional[bool] = True,
+        page: int = 1,
+        page_size: int = 20,
+        order_desc: bool = True,
+    ) -> Tuple[List[DeviceModel], int]:
+        conditions = [DeviceModel.department_id == department_id]
+        if active is not None:
+            conditions.append(DeviceModel.active == active)
+        if name:
+            conditions.append(DeviceModel.name.ilike(f"%{name.strip()}%"))
+        if model_code:
+            conditions.append(DeviceModel.model_code.ilike(f"%{model_code.strip()}%"))
+        if category:
+            conditions.append(DeviceModel.category == category)
+
+        stmt = select(DeviceModel).where(*conditions)
+        count_stmt = select(func.count(DeviceModel.id)).where(*conditions)
+
+        if order_desc:
+            stmt = stmt.order_by(desc(DeviceModel.created_at))
+        else:
+            stmt = stmt.order_by(asc(DeviceModel.created_at))
+
+        total = db.session.execute(count_stmt).scalar() or 0
+        stmt = stmt.offset((page - 1) * page_size).limit(page_size)
+        items = db.session.execute(stmt).scalars().all()
+        return items, total
+
+    @staticmethod
+    def update(device_model: DeviceModel, **kwargs) -> DeviceModel:
+        for field, value in kwargs.items():
+            if value is not None:
+                setattr(device_model, field, value)
+        db.session.flush()
+        return device_model
+
+    @staticmethod
+    def commit():
+        try:
+            db.session.commit()
+        except IntegrityError as exc:  # pragma: no cover - pass through for service handling
+            db.session.rollback()
+            raise exc
+
+    @staticmethod
+    def rollback():
+        db.session.rollback()

--- a/services/device_model_service.py
+++ b/services/device_model_service.py
@@ -1,0 +1,156 @@
+from typing import List, Optional, Tuple
+
+from sqlalchemy.exc import IntegrityError
+
+from models.device_model import DeviceModel
+from repositories.department_repository import DepartmentRepository
+from repositories.device_model_repository import DeviceModelRepository
+from utils.exceptions import BizError
+from utils.permissions import assert_user_in_department
+
+
+class DeviceModelService:
+
+    @staticmethod
+    def _ensure_department_exists(department_id: int):
+        if not department_id:
+            raise BizError("部门ID不能为空")
+        dept = DepartmentRepository.get_by_id(department_id)
+        if not dept:
+            raise BizError("部门不存在", 404)
+        return dept
+
+    @staticmethod
+    def create(
+        *,
+        department_id: int,
+        name: str,
+        user,
+        category: Optional[str] = None,
+        model_code: Optional[str] = None,
+        vendor: Optional[str] = None,
+        firmware_version: Optional[str] = None,
+        description: Optional[str] = None,
+        attributes_json: Optional[dict] = None,
+    ) -> DeviceModel:
+        DeviceModelService._ensure_department_exists(department_id)
+        assert_user_in_department(department_id, user)
+
+        if not name:
+            raise BizError("机型名称不能为空")
+
+        existing = DeviceModelRepository.get_by_dept_and_name(department_id, name)
+        if existing:
+            raise BizError("同部门下已存在同名机型")
+
+        try:
+            device_model = DeviceModelRepository.create(
+                department_id=department_id,
+                name=name.strip(),
+                category=category.strip() if category else None,
+                model_code=model_code.strip() if model_code else None,
+                vendor=vendor.strip() if vendor else None,
+                firmware_version=firmware_version.strip() if firmware_version else None,
+                description=description,
+                attributes_json=attributes_json,
+                active=True,
+            )
+            DeviceModelRepository.commit()
+        except IntegrityError:
+            raise BizError("创建机型失败：唯一约束冲突")
+
+        return device_model
+
+    @staticmethod
+    def get(device_model_id: int, user, *, include_inactive: bool = True) -> DeviceModel:
+        device_model = DeviceModelRepository.get_by_id(
+            device_model_id, include_inactive=include_inactive
+        )
+        if not device_model:
+            raise BizError("机型不存在", 404)
+        assert_user_in_department(device_model.department_id, user)
+        return device_model
+
+    @staticmethod
+    def list(
+        *,
+        department_id: int,
+        user,
+        name: Optional[str] = None,
+        model_code: Optional[str] = None,
+        category: Optional[str] = None,
+        active: Optional[bool] = True,
+        page: int = 1,
+        page_size: int = 20,
+        order_desc: bool = True,
+    ) -> Tuple[List[DeviceModel], int]:
+        DeviceModelService._ensure_department_exists(department_id)
+        assert_user_in_department(department_id, user)
+
+        return DeviceModelRepository.list(
+            department_id=department_id,
+            name=name,
+            model_code=model_code,
+            category=category,
+            active=active,
+            page=page,
+            page_size=page_size,
+            order_desc=order_desc,
+        )
+
+    @staticmethod
+    def update(
+        device_model_id: int,
+        user,
+        *,
+        name: Optional[str] = None,
+        category: Optional[str] = None,
+        model_code: Optional[str] = None,
+        vendor: Optional[str] = None,
+        firmware_version: Optional[str] = None,
+        description: Optional[str] = None,
+        attributes_json: Optional[dict] = None,
+    ) -> DeviceModel:
+        device_model = DeviceModelService.get(device_model_id, user, include_inactive=True)
+
+        if name and name.strip() != device_model.name:
+            existing = DeviceModelRepository.get_by_dept_and_name(device_model.department_id, name.strip())
+            if existing and existing.id != device_model.id:
+                raise BizError("同部门下已存在同名机型")
+
+        try:
+            DeviceModelRepository.update(
+                device_model,
+                name=name.strip() if name else None,
+                category=category.strip() if category else None,
+                model_code=model_code.strip() if model_code else None,
+                vendor=vendor.strip() if vendor else None,
+                firmware_version=firmware_version.strip() if firmware_version else None,
+                description=description,
+                attributes_json=attributes_json,
+            )
+            DeviceModelRepository.commit()
+        except IntegrityError:
+            raise BizError("更新机型失败：唯一约束冲突")
+
+        return device_model
+
+    @staticmethod
+    def set_active(device_model_id: int, user, active: bool) -> DeviceModel:
+        device_model = DeviceModelService.get(device_model_id, user, include_inactive=True)
+
+        if device_model.active == active:
+            return device_model
+
+        if active:
+            existing = DeviceModelRepository.get_by_dept_and_name(
+                device_model.department_id, device_model.name
+            )
+            if existing and existing.id != device_model.id:
+                raise BizError("同部门下已存在同名机型")
+
+        DeviceModelRepository.update(device_model, active=active)
+        DeviceModelRepository.commit()
+
+        return device_model
+


### PR DESCRIPTION
## Summary
- add category/description metadata fields to device models and expose a serialization helper
- add repository, service, and REST endpoints for managing device models, using enable/disable actions in place of delete while honoring the `active` flag
- register the device model blueprint and count only active device models in department statistics

## Testing
- pytest *(fails: missing `requests` dependency in current environment)*

------
https://chatgpt.com/codex/tasks/task_e_68c9287e016c83318ff2eb4007372ffe