### PR TITLE
Support department scoped plan queries and tester updates

### DIFF
--- a/controllers/test_plan_controller.py
+++ b/controllers/test_plan_controller.py
@@ -51,6 +51,7 @@ def list_test_plans():
         validate_plan_status(status)
     items, total = TestPlanService.list(
         project_id=args.get("project_id", type=int),
+        department_id=args.get("department_id", type=int),
         status=status,
         keyword=args.get("keyword"),
         page=args.get("page", type=int, default=1),
@@ -85,6 +86,7 @@ def update_test_plan(plan_id: int):
         status=payload.get("status"),
         start_date=payload.get("start_date"),
         end_date=payload.get("end_date"),
+        tester_user_ids=payload.get("tester_user_ids"),
     )
     return json_response(message="更新成功", data=plan.to_dict())
 

--- a/models/plan_device_model.py
+++ b/models/plan_device_model.py
@@ -20,24 +20,39 @@ class PlanDeviceModel(TimestampMixin, db.Model):
 
     id = db.Column(db.Integer, primary_key=True)
     plan_id = db.Column(db.Integer, db.ForeignKey("test_plan.id", ondelete="CASCADE"), nullable=False)
-    device_model_id = db.Column(db.Integer, db.ForeignKey("device_model.id", ondelete="CASCADE"), nullable=False)
+    device_model_id = db.Column(
+        db.Integer,
+        db.ForeignKey("device_model.id", ondelete="CASCADE"),
+        nullable=False,
+    )
+    snapshot_name = db.Column(db.String(255), nullable=False)
+    snapshot_model_code = db.Column(db.String(255))
+    snapshot_category = db.Column(db.String(64))
 
     test_plan = db.relationship("TestPlan", back_populates="plan_device_models")
     device_model = db.relationship("DeviceModel", back_populates="plan_device_models")
     execution_results = db.relationship("ExecutionResult", back_populates="plan_device_model")
 
     def to_dict(self):
-        device = None
-        if self.device_model:
-            device = {
-                "id": self.device_model.id,
-                "name": self.device_model.name,
-                "model_code": self.device_model.model_code,
-                "category": self.device_model.category,
-            }
+        name = self.snapshot_name or (self.device_model.name if self.device_model else None)
+        model_code = self.snapshot_model_code or (
+            self.device_model.model_code if self.device_model else None
+        )
+        category = self.snapshot_category or (
+            self.device_model.category if self.device_model else None
+        )
+        snapshot = {
+            "id": self.device_model_id,
+            "name": name,
+            "model_code": model_code,
+            "category": category,
+        }
         return {
             "id": self.id,
             "plan_id": self.plan_id,
             "device_model_id": self.device_model_id,
-            "device_model": device,
+            "name": name,
+            "model_code": model_code,
+            "category": category,
+            "device_model": snapshot,
         }

--- a/models/plan_tester.py
+++ b/models/plan_tester.py
@@ -25,11 +25,12 @@ class TestPlanTester(TimestampMixin, db.Model):
     tester = db.relationship("User", backref=db.backref("plan_assignments", cascade="all, delete-orphan"))
 
     def to_dict(self):
+        username = self.tester.username if self.tester else None
         user = None
         if self.tester:
             user = {
                 "id": self.tester.id,
-                "username": self.tester.username,
+                "username": username,
                 "email": self.tester.email,
                 "role": self.tester.role,
             }
@@ -37,5 +38,6 @@ class TestPlanTester(TimestampMixin, db.Model):
             "id": self.id,
             "plan_id": self.plan_id,
             "user_id": self.user_id,
+            "name": username,
             "tester": user,
         }

--- a/repositories/test_plan_repository.py
+++ b/repositories/test_plan_repository.py
@@ -6,6 +6,7 @@ from sqlalchemy import asc, desc, func, select
 from sqlalchemy.orm import selectinload
 
 from extensions.database import db
+from models.project import Project
 from models.test_plan import TestPlan
 from models.plan_case import PlanCase
 from models.plan_device_model import PlanDeviceModel
@@ -41,6 +42,7 @@ class TestPlanRepository:
     @staticmethod
     def list(
         project_id: Optional[int] = None,
+        department_id: Optional[int] = None,
         status: Optional[str] = None,
         keyword: Optional[str] = None,
         page: int = 1,
@@ -57,6 +59,8 @@ class TestPlanRepository:
         conditions = []
         if project_id:
             conditions.append(TestPlan.project_id == project_id)
+        if department_id:
+            conditions.append(TestPlan.project.has(Project.department_id == department_id))
         if status:
             conditions.append(TestPlan.status == status)
         if keyword:

--- a/tests/plans/test_plan_service_unit.py
+++ b/tests/plans/test_plan_service_unit.py
@@ -1,0 +1,170 @@
+# -*- coding: utf-8 -*-
+"""单元测试：验证测试计划服务层新增能力。"""
+
+from __future__ import annotations
+
+import uuid
+
+import pytest
+
+from app import create_app
+from extensions.database import db
+from models import (
+    Department,
+    DepartmentMember,
+    DeviceModel,
+    Project,
+    TestCase,
+    TestPlan,
+    User,
+)
+from services.test_plan_service import TestPlanService
+
+
+@pytest.fixture()
+def app_context():
+    """提供测试用的 Flask 应用上下文（使用内存数据库）。"""
+
+    app = create_app("testing")
+    with app.app_context():
+        db.create_all()
+        yield app
+        db.session.remove()
+        db.drop_all()
+
+
+def _random_text(prefix: str) -> str:
+    return f"{prefix}-{uuid.uuid4().hex[:8]}"
+
+
+def _bootstrap_plan_environment() -> dict[str, object]:
+    """创建测试计划所需的基础数据。"""
+
+    department = Department(name=_random_text("Dept"), code=_random_text("D"))
+    db.session.add(department)
+
+    project = Project(
+        department=department,
+        name=_random_text("Project"),
+        code=_random_text("PRJ"),
+    )
+    db.session.add(project)
+
+    device = DeviceModel(
+        department=department,
+        name=_random_text("Device"),
+        category="headset",
+        model_code=_random_text("MDL"),
+    )
+    db.session.add(device)
+
+    case = TestCase(
+        department=department,
+        title=_random_text("Case"),
+        steps=[{"no": 1, "action": "step", "expected": "result"}],
+        expected_result="result",
+        keywords=[],
+        priority="P1",
+    )
+    db.session.add(case)
+
+    tester_a = User(username=_random_text("tester"), password_hash="hash", role="user")
+    tester_b = User(username=_random_text("tester"), password_hash="hash", role="user")
+    db.session.add_all([tester_a, tester_b])
+
+    db.session.flush()
+
+    db.session.add_all(
+        [
+            DepartmentMember(department_id=department.id, user_id=tester_a.id),
+            DepartmentMember(department_id=department.id, user_id=tester_b.id),
+        ]
+    )
+
+    db.session.flush()
+
+    return {
+        "department": department,
+        "project": project,
+        "device": device,
+        "case": case,
+        "tester_a": tester_a,
+        "tester_b": tester_b,
+    }
+
+
+def _create_plan() -> TestPlan:
+    env = _bootstrap_plan_environment()
+    plan = TestPlanService.create(
+        current_user=None,
+        project_id=env["project"].id,
+        name=_random_text("Plan"),
+        description="demo",
+        status="active",
+        case_ids=[env["case"].id],
+        case_group_ids=[],
+        single_execution_case_ids=[],
+        device_model_ids=[env["device"].id],
+        tester_user_ids=[env["tester_a"].id, env["tester_b"].id],
+    )
+    return plan
+
+
+def test_device_snapshot_and_name_fields(app_context):
+    """机型需要做快照，并在详情中返回名称。"""
+
+    plan = _create_plan()
+    device_name = plan.plan_device_models[0].snapshot_name
+
+    # 修改原始机型名称不应影响计划中的快照名称
+    plan.plan_device_models[0].device_model.name = "updated-name"
+    db.session.commit()
+
+    refreshed = TestPlanService.get(plan.id)
+    device_entries = refreshed.to_dict()["device_models"]
+
+    assert device_entries[0]["name"] == device_name
+    # 同时返回 tester 名称方便前端展示
+    tester_names = {item["name"] for item in refreshed.to_dict()["testers"]}
+    expected_names = {t.tester.username for t in refreshed.plan_testers}
+    assert tester_names == expected_names
+
+
+def test_list_supports_department_filter(app_context):
+    """列表接口支持按部门过滤。"""
+
+    first_plan = _create_plan()
+    first_department_id = first_plan.project.department_id
+
+    second_plan = _create_plan()
+
+    items, total = TestPlanService.list(department_id=first_department_id)
+    item_ids = {item.id for item in items}
+
+    assert total == 1
+    assert item_ids == {first_plan.id}
+    assert second_plan.id not in item_ids
+
+
+def test_update_plan_allows_modifying_testers(app_context):
+    """编辑测试计划时可调整执行人列表。"""
+
+    plan = _create_plan()
+    department_id = plan.project.department_id
+
+    # 新增一名同部门测试人员
+    extra_user = User(username=_random_text("tester"), password_hash="hash", role="user")
+    db.session.add(extra_user)
+    db.session.flush()
+    db.session.add(DepartmentMember(department_id=department_id, user_id=extra_user.id))
+    db.session.flush()
+
+    keep_user_id = plan.plan_testers[0].user_id
+    updated = TestPlanService.update(
+        plan.id,
+        current_user=None,
+        tester_user_ids=[keep_user_id, extra_user.id],
+    )
+
+    tester_ids = {tester.user_id for tester in updated.plan_testers}
+    assert tester_ids == {keep_user_id, extra_user.id}


### PR DESCRIPTION
## Summary
- allow filtering test plan listings by department in controller, service and repository
- snapshot device model attributes when creating plans and expose tester/device names in plan details
- enable editing assigned testers on plan updates and add unit tests covering the new behaviours

## Testing
- python - <<'PY'
import sys, types

stub = types.ModuleType("requests")

class DummyResponse:
    status_code = 0
    headers = {}
    def json(self):
        return {}

class DummySession:
    def request(self, *args, **kwargs):
        raise RuntimeError("requests is not available in test environment")

class DummyRequestException(Exception):
    pass

stub.Session = DummySession
stub.RequestException = DummyRequestException
stub.Response = DummyResponse
sys.modules.setdefault("requests", stub)

import pytest
raise SystemExit(pytest.main(["tests/plans/test_plan_service_unit.py"]))
PY

------
https://chatgpt.com/codex/tasks/task_e_68ca6e0c139c8331b712def52f1f8b19