### PR TITLE
Include department metadata in test plan responses

### DIFF
--- a/models/test_plan.py
+++ b/models/test_plan.py
@@ -49,6 +49,8 @@ class TestPlan(TimestampMixin, db.Model):
             "id": self.id,
             "project_id": self.project_id,
             "project_name": self.project.name if self.project else None,
+            "department_id": self.project.department_id if self.project else None,
+            "department_name": self.project.department.name if self.project and self.project.department else None,
             "name": self.name,
             "status": self.status,
             "description": self.description,

--- a/repositories/test_plan_repository.py
+++ b/repositories/test_plan_repository.py
@@ -29,7 +29,7 @@ class TestPlanRepository:
         stmt = select(TestPlan)
         if load_details:
             stmt = stmt.options(
-                selectinload(TestPlan.project),
+                selectinload(TestPlan.project).selectinload(Project.department),
                 selectinload(TestPlan.creator),
                 selectinload(TestPlan.plan_cases).selectinload(PlanCase.execution_results),
                 selectinload(TestPlan.plan_device_models).selectinload(PlanDeviceModel.device_model),
@@ -50,7 +50,7 @@ class TestPlanRepository:
         order_desc: bool = True,
     ) -> Tuple[List[TestPlan], int]:
         stmt = select(TestPlan).options(
-            selectinload(TestPlan.project),
+            selectinload(TestPlan.project).selectinload(Project.department),
             selectinload(TestPlan.plan_device_models).selectinload(PlanDeviceModel.device_model),
             selectinload(TestPlan.plan_testers).selectinload(TestPlanTester.tester),
         )


### PR DESCRIPTION
## Summary
- add department id and name to the serialized test plan payload
- eager load project departments when fetching plans to avoid extra queries

## Testing
- `pytest` *(fails: missing dependency `requests` in test environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cb6c8cb52c83318b840f9428850a7d