### PR TITLE
feat: support importing test cases from excel

### DIFF
--- a/controllers/up_files.py
+++ b/controllers/up_files.py
@@ -1,137 +1,188 @@
 # -*- coding: utf-8 -*-
-# Update parser per new rules:
-# - keywords: array of strings WITHOUT brackets, e.g. ["时间+1","S3+5"]
-# - steps: keep expected empty in each step dict
-# - case-level expected_result: put the entire expected_text
-import re, json
-import pandas as pd
+"""Utilities for parsing uploaded Excel test case files."""
+
+from __future__ import annotations
+
+import re
+from io import BytesIO
 from pathlib import Path
+from typing import Any, BinaryIO, Dict, List, Tuple
+
+import pandas as pd
 
 
-SRC = Path(r"C:\Users\71958\Downloads\01 Mouse Test information.xlsx")
-SHEET = 0
+SKIP_PREFIX = (
+    "Section :",
+    "Workloading :",
+    "Leadingtime :",
+    "Phase :",
+    "Test Log Mandatory :",
+)
+STEP_SPLIT_RE = re.compile(r"(?:^|\n)\s*(\d+)[\.\)\、:：]\s*", re.M)
+TITLE_KEYWORD_RE = re.compile(r"\[([^\]]+)\]")  # capture inner token
 
-SKIP_PREFIX = ('Section :', 'Workloading :', 'Leadingtime :', 'Phase :', 'Test Log Mandatory :')
-STEP_SPLIT_RE = re.compile(r'(?:^|\n)\s*(\d+)[\.\)\、:：]\s*', re.M)
-TITLE_KEYWORD_RE = re.compile(r'\[([^\]]+)\]')  # capture inner token
 
-def extract_folder_name(df):
-    return str(df.iloc[1, 3]).strip() if pd.notna(df.iloc[1, 3]) else ""
+def _normalize_text(value: Any) -> str:
+    if isinstance(value, str):
+        text = value.strip()
+        return "" if text.lower() == "nan" else text
+    if pd.isna(value):  # type: ignore[arg-type]
+        return ""
+    return str(value).strip()
 
-def find_header_idx(df):
+
+def extract_folder_name(df: pd.DataFrame) -> str:
+    if df.shape[0] > 1 and df.shape[1] > 3:
+        value = df.iloc[1, 3]
+        return _normalize_text(value)
+    return ""
+
+
+def find_header_idx(df: pd.DataFrame) -> int | None:
     for i in range(len(df)):
-        v = str(df.iloc[i, 0]) if pd.notna(df.iloc[i, 0]) else ""
+        v = _normalize_text(df.iloc[i, 0])
         if "Test case item" in v:
             return i
     return None
 
-def is_title_row(df, i):
-    a = df.iloc[i, 0]; e = df.iloc[i, 4] if df.shape[1] > 4 else None
-    if pd.isna(a) or str(a).strip()=="":
-        return False
-    a = str(a).strip()
-    if any(a.startswith(k) for k in SKIP_PREFIX):
-        return False
-    return (pd.isna(e) or str(e).strip()=="")
 
-def has_step_and_expected(df, i):
-    a = df.iloc[i, 0]; e = df.iloc[i, 4] if df.shape[1] > 4 else None
-    return pd.notna(a) and str(a).strip()!="" and pd.notna(e) and str(e).strip()!=""
+def is_title_row(df: pd.DataFrame, index: int) -> bool:
+    title = _normalize_text(df.iloc[index, 0])
+    expected = _normalize_text(df.iloc[index, 4]) if df.shape[1] > 4 else ""
+    if not title:
+        return False
+    if any(title.startswith(prefix) for prefix in SKIP_PREFIX):
+        return False
+    return expected == ""
 
-def split_numbered(text: str):
-    s = (text or "").strip()
-    if not s: return []
-    parts, ms = [], list(STEP_SPLIT_RE.finditer(s))
-    if ms:
-        if ms[0].start()!=0:
-            head = s[:ms[0].start()].strip()
-            if head: parts.append((1, head))
-        for i, m in enumerate(ms):
-            no = int(m.group(1))
-            start, end = m.end(), (ms[i+1].start() if i+1<len(ms) else len(s))
-            chunk = s[start:end].strip()
-            if chunk: parts.append((no, chunk))
-    else:
-        lines = [ln.strip() for ln in s.splitlines() if ln.strip()]
-        parts = [(i+1, ln) for i, ln in enumerate(lines or [""])]
+
+def has_step_and_expected(df: pd.DataFrame, index: int) -> bool:
+    action = _normalize_text(df.iloc[index, 0])
+    expected = _normalize_text(df.iloc[index, 4]) if df.shape[1] > 4 else ""
+    return bool(action) and bool(expected)
+
+
+def split_numbered(text: str) -> List[Tuple[int, str]]:
+    source = (text or "").strip()
+    if not source:
+        return []
+
+    matches = list(STEP_SPLIT_RE.finditer(source))
+    if not matches:
+        lines = [ln.strip() for ln in source.splitlines() if ln.strip()]
+        return [(idx + 1, ln) for idx, ln in enumerate(lines or [source])]
+
+    parts: List[Tuple[int, str]] = []
+    if matches[0].start() != 0:
+        head = source[: matches[0].start()].strip()
+        if head:
+            parts.append((1, head))
+
+    for idx, match in enumerate(matches):
+        number = int(match.group(1))
+        start = match.end()
+        end = matches[idx + 1].start() if idx + 1 < len(matches) else len(source)
+        chunk = source[start:end].strip()
+        if chunk:
+            parts.append((number, chunk))
+
     return parts
 
-def extract_title_and_keywords(title: str):
-    s = title or ""
-    # keywords: inner token without brackets, trimmed
-    kws = [m.strip() for m in TITLE_KEYWORD_RE.findall(s)]
-    cleaned = TITLE_KEYWORD_RE.sub('', s).strip()
-    cleaned = re.sub(r'\s{2,}', ' ', cleaned).strip(' -—_/')
-    return cleaned, kws
 
-def parse_excel(path: Path, sheet):
-    df = pd.read_excel(path, sheet_name=sheet, header=None)
-    df.columns = ['A','B','C','D','E','F','G','H']
+def extract_title_and_keywords(title: str) -> Tuple[str, List[str]]:
+    tokens = TITLE_KEYWORD_RE.findall(title or "")
+    keywords = [token.strip() for token in tokens if token.strip()]
+    cleaned = TITLE_KEYWORD_RE.sub("", title or "").strip()
+    cleaned = re.sub(r"\s{2,}", " ", cleaned).strip(" -—_/")
+    return cleaned, keywords
+
+
+def _ensure_min_columns(df: pd.DataFrame, count: int = 8) -> pd.DataFrame:
+    df = df.reindex(columns=range(count))
+    labels = [chr(ord("A") + idx) for idx in range(count)]
+    df.columns = labels
+    return df
+
+
+def parse_excel_cases(data: BinaryIO | BytesIO | Path, sheet: int = 0) -> Tuple[str, List[Dict[str, Any]]]:
+    """Parse the uploaded Excel file and return folder name plus case payloads."""
+
+    if isinstance(data, (bytes, bytearray)):
+        buffer: BytesIO | BinaryIO = BytesIO(data)
+    else:
+        buffer = data  # type: ignore[assignment]
+
+    df = pd.read_excel(buffer, sheet_name=sheet, header=None)
+    df = _ensure_min_columns(df)
+
     folder = extract_folder_name(df)
     header = find_header_idx(df)
 
-    i = (header + 1) if header is not None else 0
-    order, cases, preview_rows = 1, [], []
-    while i < len(df)-1:
-        if is_title_row(df, i):
-            raw_title = str(df.iloc[i,0]).strip()
-            j = i + 1
-            while j < len(df) and not has_step_and_expected(df, j):
-                if is_title_row(df, j): break
-                j += 1
-            if j < len(df) and has_step_and_expected(df, j):
-                steps_text = str(df.iloc[j,0]).strip()
-                expected_text = str(df.iloc[j,4]).strip()
+    index = (header + 1) if header is not None else 0
+    order = 1
+    cases: List[Dict[str, Any]] = []
+
+    while index < len(df) - 1:
+        if is_title_row(df, index):
+            raw_title = _normalize_text(df.iloc[index, 0])
+            inner_index = index + 1
+
+            while inner_index < len(df) and not has_step_and_expected(df, inner_index):
+                if is_title_row(df, inner_index):
+                    break
+                inner_index += 1
+
+            if inner_index < len(df) and has_step_and_expected(df, inner_index):
+                steps_text = _normalize_text(df.iloc[inner_index, 0])
+                expected_text = _normalize_text(df.iloc[inner_index, 4])
 
                 title, keywords = extract_title_and_keywords(raw_title)
                 steps_split = split_numbered(steps_text)
 
-                steps_payload = [{
-                    "no": no,
-                    "action": act,
-                    "keyword": "",
-                    "note": "",
-                    "expected": ""     # step-level expected intentionally empty
-                } for no, act in steps_split]
+                steps_payload = [
+                    {
+                        "no": number,
+                        "action": action,
+                        "keyword": "",
+                        "note": "",
+                        "expected": "",
+                    }
+                    for number, action in steps_split
+                ]
 
-                cases.append({
-                    "order": order,
-                    "folder": folder,
-                    "title": title,
-                    "keywords": keywords,           # e.g. ["时间+1","S3+5"]
-                    "expected_result": expected_text,  # full expected into case field
-                    "steps": steps_payload
-                })
+                cases.append(
+                    {
+                        "order": order,
+                        "folder": folder,
+                        "title": title or raw_title,
+                        "keywords": keywords,
+                        "expected_result": expected_text,
+                        "steps": steps_payload,
+                    }
+                )
 
-                preview_rows.append({
-                    "order": order,
-                    "folder": folder,
-                    "raw_title": raw_title,
-                    "title": title,
-                    "keywords": ", ".join(keywords),
-                    "expected_result": expected_text,
-                    "steps_obj": json.dumps(steps_payload, ensure_ascii=False)
-                })
                 order += 1
-                i = j + 1
+                index = inner_index + 1
                 continue
-        i += 1
-    return folder, cases, pd.DataFrame(preview_rows)
 
-folder, cases, preview_df = parse_excel(SRC, SHEET)
+        index += 1
 
-# outputs
-json_path = "test_cases_for_backend_v2.json"
-xlsx_path = "test_cases_for_backend_v2.xlsx"
-with open(json_path, "w", encoding="utf-8") as f:
-    json.dump(cases, f, ensure_ascii=False, indent=2)
-preview_df.to_excel(xlsx_path, index=False)
+    return folder, cases
 
-# display_dataframe_to_user("Parsed Cases (v2 preview)", preview_df)
 
-print(f"Folder: {folder}")
-print(f"Total cases: {len(cases)}")
-print(f"JSON saved to: {json_path}")
-print(f"XLSX saved to: {xlsx_path}")
-print("\n--- FULL JSON ---\n")
-print(json.dumps(cases, ensure_ascii=False, indent=2))
+__all__ = [
+    "parse_excel_cases",
+    "extract_folder_name",
+    "split_numbered",
+]
+
+
+if __name__ == "__main__":  # pragma: no cover - manual debug helper
+    sample_path = Path(__file__).with_name("01 Mouse Test information.xlsx")
+    if sample_path.exists():
+        with sample_path.open("rb") as file:
+            folder_name, parsed_cases = parse_excel_cases(file)
+        print(f"Folder: {folder_name}")
+        print(f"Total cases: {len(parsed_cases)}")
+    else:
+        print("Sample Excel file not found.")

--- a/repositories/case_group_repository.py
+++ b/repositories/case_group_repository.py
@@ -54,6 +54,22 @@ class CaseGroupRepository:
         return db.session.query(q.exists()).scalar()
 
     @staticmethod
+    def get_by_name_under_parent(
+        department_id: int,
+        parent_id: Optional[int],
+        name: str,
+        include_deleted: bool = False
+    ) -> Optional[CaseGroup]:
+        q = CaseGroup.query.filter(
+            CaseGroup.department_id == department_id,
+            CaseGroup.parent_id == parent_id,
+            CaseGroup.name == name
+        )
+        if not include_deleted and hasattr(CaseGroup, "is_deleted"):
+            q = q.filter(CaseGroup.is_deleted.is_(False))
+        return q.first()
+
+    @staticmethod
     def create(**kwargs) -> CaseGroup:
         group = CaseGroup(**kwargs)
         db.session.add(group)

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,5 @@ PyMySQL
 Werkzeug
 boto3
 requests
+pandas
+openpyxl

--- a/services/case_group_service.py
+++ b/services/case_group_service.py
@@ -29,6 +29,27 @@ class CaseGroupService:
         return group
 
     @staticmethod
+    def get_or_create_by_name(
+        department_id: int,
+        name: str,
+        user,
+        parent_id: Optional[int] = None,
+        order_no: int = 0
+    ) -> CaseGroup:
+        """根据名称获取或创建分组"""
+        assert_user_in_department(department_id, user)
+        existing = CaseGroupRepository.get_by_name_under_parent(department_id, parent_id, name)
+        if existing:
+            return existing
+        return CaseGroupService.create(
+            department_id=department_id,
+            name=name,
+            user=user,
+            parent_id=parent_id,
+            order_no=order_no
+        )
+
+    @staticmethod
     def create(department_id: int, name: str, user, parent_id: Optional[int] = None, order_no: int = 0) -> CaseGroup:
         assert_user_in_department(department_id, user)
 


### PR DESCRIPTION
## Summary
- update the batch import API to accept Excel uploads, parse cases with the new helper, and ensure they are stored under the correct directory (creating it when needed)
- refactor the Excel parsing utility into reusable functions for converting spreadsheets into case payloads
- add repository/service helpers and dependencies required to resolve or create target case directories during import

## Testing
- `pip install -r requirements.txt`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68cbcadff3d083319f063970cbf275db