### PR TITLE
Fix batch import order to match Excel sequence

### DIFF
--- a/services/test_case_service.py
+++ b/services/test_case_service.py
@@ -344,10 +344,12 @@ class TestCaseService:
         if not cases_data:
             raise BizError("导入的用例数据不能为空", 400)
 
-        created_cases: List[TestCase] = []
+        cases_with_index = list(enumerate(cases_data, start=1))
+
+        created_case_entries: List[Tuple[int, TestCase]] = []
         errors: List[Dict[str, Any]] = []
 
-        for index, case_payload in enumerate(cases_data, start=1):
+        for index, case_payload in reversed(cases_with_index):
             if not isinstance(case_payload, dict):
                 errors.append({
                     "index": index,
@@ -380,7 +382,7 @@ class TestCaseService:
                     group_id=case_payload.get("group_id"),
                     workload_minutes=case_payload.get("workload_minutes")
                 )
-                created_cases.append(test_case)
+                created_case_entries.append((index, test_case))
             except BizError as exc:
                 errors.append({
                     "index": index,
@@ -396,8 +398,11 @@ class TestCaseService:
                     "code": 500
                 })
 
+        created_case_entries.sort(key=lambda item: item[0])
+        errors.sort(key=lambda item: item.get("index", 0))
+
         return {
-            "created": created_cases,
+            "created": [case for _, case in created_case_entries],
             "errors": errors
         }
 

--- a/tests/case/test_batch_import_order.py
+++ b/tests/case/test_batch_import_order.py
@@ -1,0 +1,53 @@
+from types import SimpleNamespace
+
+from constants.test_case import TestCasePriority, TestCaseType
+from services.test_case_service import TestCaseService
+
+
+def test_batch_import_creates_cases_in_reverse_order(monkeypatch):
+    department_id = 42
+    user = SimpleNamespace(id=7)
+
+    cases_data = [
+        {"title": "case-1"},
+        {"title": "case-2"},
+        {"title": "case-3"},
+    ]
+
+    created_titles = []
+
+    def fake_create(*, department_id, title, created_by, **kwargs):
+        created_titles.append(title)
+        return SimpleNamespace(
+            id=len(created_titles),
+            title=title,
+            department_id=department_id,
+            group_id=kwargs.get("group_id"),
+            priority=kwargs.get("priority") or TestCasePriority.P2.value,
+            case_type=kwargs.get("case_type") or TestCaseType.FUNCTIONAL.value,
+            status="active",
+            version=1,
+            created_at=None,
+        )
+
+    monkeypatch.setattr(
+        TestCaseService,
+        "create",
+        staticmethod(fake_create),
+    )
+    monkeypatch.setattr(
+        "services.test_case_service.assert_user_in_department",
+        lambda dept_id, user: None,
+    )
+
+    result = TestCaseService.batch_import(
+        department_id=department_id,
+        cases_data=cases_data,
+        user=user,
+    )
+
+    assert created_titles == ["case-3", "case-2", "case-1"]
+
+    returned_titles = [case.title for case in result["created"]]
+    assert returned_titles == ["case-1", "case-2", "case-3"]
+    assert result["errors"] == []


### PR DESCRIPTION
## Summary
- ensure batch imports create cases in reverse order so descending IDs match the original Excel sequence
- keep returned success and error payloads sorted by the original indices
- add a regression test covering the reversed creation order logic with monkeypatched dependencies

## Testing
- `pytest tests/case/test_batch_import_order.py` *(fails: missing `requests` dependency in test harness environment)*
- `python - <<'PY' ...` *(manual execution validating ordering logic)*

------
https://chatgpt.com/codex/tasks/task_e_68cbe4d0cfdc83319ff8bbd50b6491c2