### PR TITLE
Update test plan overview defaults

### DIFF
--- a/controllers/test_plan_controller.py
+++ b/controllers/test_plan_controller.py
@@ -69,11 +69,8 @@ def list_test_plans():
 @test_plan_bp.get("/<int:plan_id>")
 @auth_required()
 def get_test_plan(plan_id: int):
-    include_param = request.args.get("include")
-    includes = []
-    if include_param:
-        includes = [item.strip() for item in include_param.split(",") if item.strip()]
-    data = TestPlanService.get_overview(plan_id, includes=includes)
+    default_includes = ["stats", "testers", "device_models"]
+    data = TestPlanService.get_overview(plan_id, includes=default_includes)
     return json_response(data=data)
 
 

--- a/services/test_plan_service.py
+++ b/services/test_plan_service.py
@@ -428,6 +428,8 @@ class TestPlanService:
     # ------------------------------------------------------------------
     @staticmethod
     def get_overview(plan_id: int, includes: Optional[Iterable[str]] = None) -> Dict:
+        if not includes:
+            includes = ("stats", "testers", "device_models")
         include_set = TestPlanService._normalize_includes(includes)
         include_stats = "stats" in include_set
         include_testers = "testers" in include_set
@@ -458,6 +460,14 @@ class TestPlanService:
             "start_date": plan.start_date.isoformat() if plan.start_date else None,
             "end_date": plan.end_date.isoformat() if plan.end_date else None,
             "project": project_payload,
+            "created_by": plan.created_by,
+            "creator": {
+                "id": plan.creator.id,
+                "username": plan.creator.username,
+            }
+            if plan.creator
+            else None,
+            "created_at": plan.created_at.isoformat() if plan.created_at else None,
             "updated_at": plan.updated_at.isoformat() if plan.updated_at else None,
         }
 


### PR DESCRIPTION
## Summary
- remove the include query parameter handling from the test plan detail API in favor of default data
- default the service layer to load statistics, testers, and device models while returning creator metadata

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d60ba4e9648331a2400e0b4d2fe8cf