### PR TITLE
Support filters for test plan case listing

### DIFF
--- a/models/execution.py
+++ b/models/execution.py
@@ -125,7 +125,12 @@ class ExecutionResult(TimestampMixin, db.Model):
         viewonly=True,
     )
 
-    def to_dict(self):
+    def to_dict(
+        self,
+        *,
+        include_attachments: bool = True,
+        include_history: bool = True,
+    ):
         device_name = None
         device_model_code = None
         device_category = None
@@ -167,7 +172,7 @@ class ExecutionResult(TimestampMixin, db.Model):
                 "username": executor_name,
             }
 
-        return {
+        data = {
             "id": self.id,
             "run_id": self.run_id,
             "plan_case_id": self.plan_case_id,
@@ -188,9 +193,19 @@ class ExecutionResult(TimestampMixin, db.Model):
             "device_model_code": device_model_code,
             "device_model_category": device_category,
             "device_model": device_payload,
-            "attachments": [attachment.to_dict() for attachment in self.attachments],
-            "history": [log.to_dict() for log in self.logs],
         }
+
+        if include_attachments:
+            data["attachments"] = [attachment.to_dict() for attachment in self.attachments]
+        else:
+            data["attachments"] = []
+
+        if include_history:
+            data["history"] = [log.to_dict() for log in self.logs]
+        else:
+            data["history"] = []
+
+        return data
 
 
 class ExecutionResultLog(TimestampMixin, db.Model):

--- a/models/plan_case.py
+++ b/models/plan_case.py
@@ -56,7 +56,12 @@ class PlanCase(TimestampMixin, db.Model):
     origin_case = db.relationship("TestCase", back_populates="plan_cases")
     execution_results = db.relationship("ExecutionResult", back_populates="plan_case")
 
-    def to_dict(self, include_results: bool = True):
+    def to_dict(
+        self,
+        *,
+        include_results: bool = True,
+        include_result_details: bool = True,
+    ):
         data = {
             "id": self.id,
             "plan_id": self.plan_id,
@@ -78,7 +83,12 @@ class PlanCase(TimestampMixin, db.Model):
         if include_results:
             results = []
             for result in self.execution_results:
-                results.append(result.to_dict())
+                results.append(
+                    result.to_dict(
+                        include_attachments=include_result_details,
+                        include_history=include_result_details,
+                    )
+                )
                 if result.result != ExecutionResultStatus.PENDING.value:
                     ts = result.executed_at or result.updated_at
                     if not latest_at or (ts and ts > latest_at):


### PR DESCRIPTION
## Summary
- add query parsing to the plan case list endpoint so callers can filter by group, title, priority, and execution status and optionally request grouped data
- filter plan case collections in the service layer with validation of result statuses and helper logic for latest execution status

## Testing
- pytest *(fails: login to external auth service returns 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68d65cd078c88331989e222366a1bbad