### PR TITLE
feat: enhance test plan case filtering

### DIFF
--- a/config/settings.py
+++ b/config/settings.py
@@ -36,6 +36,7 @@ class BaseConfig:
     ATTACHMENT_STORAGE_DIR = os.getenv(
         "ATTACHMENT_STORAGE_DIR", os.path.join(BASE_DIR, "storage")
     )
+    ATTACHMENT_BASE_URL = os.getenv("ATTACHMENT_BASE_URL")
 
     # 默认管理员（首次启动自动创建，可选）
     ADMIN_INIT_USERNAME = os.getenv("ADMIN_INIT_USERNAME", "admin")

--- a/models/execution.py
+++ b/models/execution.py
@@ -197,13 +197,9 @@ class ExecutionResult(TimestampMixin, db.Model):
 
         if include_attachments:
             data["attachments"] = [attachment.to_dict() for attachment in self.attachments]
-        else:
-            data["attachments"] = []
 
         if include_history:
             data["history"] = [log.to_dict() for log in self.logs]
-        else:
-            data["history"] = []
 
         return data
 

--- a/services/test_plan_service.py
+++ b/services/test_plan_service.py
@@ -232,6 +232,7 @@ class TestPlanService:
         title_keyword: Optional[str] = None,
         priorities: Optional[Sequence[str]] = None,
         statuses: Optional[Sequence[str]] = None,
+        device_model_id: Optional[int] = None,
     ) -> List[PlanCase]:
         plan = TestPlanRepository.get_by_id(
             plan_id,
@@ -315,6 +316,17 @@ class TestPlanService:
                     continue
 
             filtered.append(plan_case)
+
+        if device_model_id is not None:
+            filtered = [
+                plan_case
+                for plan_case in filtered
+                if (not plan_case.require_all_devices)
+                or any(
+                    result.device_model_id == device_model_id
+                    for result in plan_case.execution_results
+                )
+            ]
 
         return filtered
 


### PR DESCRIPTION
## Summary
- add device model filtering to the test plan case listing API and omit attachments/history from list responses
- expose attachment URLs in the test plan case detail response with configurable base URL support

## Testing
- python -m compileall controllers/test_plan_controller.py models/plan_case.py models/execution.py services/test_plan_service.py

------
https://chatgpt.com/codex/tasks/task_e_68d6692f66dc8331a39f1c76448053ad