### PR TITLE
Fix selectinload chaining for test plan case result relationships

### DIFF
--- a/repositories/test_plan_repository.py
+++ b/repositories/test_plan_repository.py
@@ -60,14 +60,19 @@ class TestPlanRepository:
             options.append(run_loader)
         if load_cases:
             case_loader = selectinload(TestPlan.plan_cases)
+
             if load_case_results:
-                case_loader = case_loader.selectinload(PlanCase.execution_results)
+                results_loader = case_loader.selectinload(PlanCase.execution_results)
+
                 if load_case_result_attachments:
-                    case_loader = case_loader.selectinload(ExecutionResult.attachments)
+                    results_loader.selectinload(ExecutionResult.attachments)
+
                 if load_case_result_logs:
-                    case_loader = case_loader.selectinload(ExecutionResult.logs)
+                    logs_loader = results_loader.selectinload(ExecutionResult.logs)
+
                     if load_case_result_log_attachments:
-                        case_loader = case_loader.selectinload(ExecutionResultLog.attachments)
+                        logs_loader.selectinload(ExecutionResultLog.attachments)
+
             options.append(case_loader)
 
         if options:


### PR DESCRIPTION
## Summary
- ensure the test plan case loader chains selectinload paths without overwriting the base relationship
- load execution result attachments and logs using properly scoped loaders to avoid SQLAlchemy argument errors

## Testing
- pytest *(fails: relies on external authentication endpoint returning 403)*

------
https://chatgpt.com/codex/tasks/task_e_68d8f9918a9c8331beefaa5cc9b2e570