### PR TITLE
Handle JSON arrays/objects and dict items when splitting tester names

### DIFF
--- a/services/feiyan_service.py
+++ b/services/feiyan_service.py
@@ -237,10 +237,27 @@ def _split_tester_names(value: Any) -> List[str]:
         for item in value:
             if item is None:
                 continue
+            if isinstance(item, dict):
+                for dict_value in item.values():
+                    if dict_value is None:
+                        continue
+                    text = str(dict_value).strip()
+                    if text:
+                        parts.append(text)
+                continue
             text = str(item).strip()
             if text:
                 parts.append(text)
         return parts
+    if isinstance(value, str):
+        raw = value.strip()
+        if raw.startswith("[") or raw.startswith("{"):
+            try:
+                parsed = json.loads(raw)
+            except (TypeError, ValueError):
+                parsed = None
+            if parsed is not None:
+                return _split_tester_names(parsed)
     raw = str(value).strip()
     if not raw:
         return []


### PR DESCRIPTION
### Motivation
- The tester-name parsing needed to handle inputs where the data is an array containing JSON objects or where a JSON string encodes an array/object, so plan execution permission checks can find matching usernames.
- This change is aimed at accepting commonly-observed payload shapes (lists of dicts or JSON-encoded lists/objects) instead of only plain comma-separated strings.

### Description
- When `_split_tester_names` receives a list and an item is a `dict`, the code now collects the dict values as candidate names.
- When `_split_tester_names` receives a `str` that starts with `[` or `{`, it attempts `json.loads` and recursively processes the parsed structure via `_split_tester_names`.
- Existing fallback behavior that normalizes separators and splits on commas remains unchanged.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69840f63bb7c832d957752e3ea264b44)